### PR TITLE
feat: add support for max sample rate

### DIFF
--- a/src/__test__/exampleEvents.telemetry.ts
+++ b/src/__test__/exampleEvents.telemetry.ts
@@ -11,3 +11,10 @@ export const ExampleEvent = defineEvent<{foo: 'bar'}>({
   version: 1,
   description: 'An example event happened',
 })
+
+export const ExampleSampledEvent = defineEvent<{sampledAt: string}>({
+  name: 'ExampleSampledEvent',
+  version: 1,
+  description: 'An example event happened',
+  maxSampleRate: 10,
+})

--- a/src/defineEvent.ts
+++ b/src/defineEvent.ts
@@ -11,6 +11,7 @@ export function defineEvent<Data = void>(
     name: options.name,
     version: options.version,
     description: options.description,
+    maxSampleRate: options.maxSampleRate,
     schema: undefined as unknown as Data,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ export interface TelemetryLogOptions {
   version: number
   /** Description of log event */
   description: string
+
+  /**
+   * Max sample rate of this event.
+   * Calling telemetry.log(EventDefinition, data) repeatedly will submit at most one event every specified time interval (in milliseconds)
+   * */
+  maxSampleRate?: number
 }
 export interface TelemetryUserPropertyOptions {
   /** Data format version. Increment this by 1 whenever the shape of the data changes in a non-backwards compatible way */
@@ -30,6 +36,13 @@ export interface DefinedTelemetryLog<Schema> {
 
   /** Description of log event */
   description?: string
+
+  /**
+   * Max sample rate of this event.
+   * Calling telemetry.log(EventDefinition, data) repeatedly will submit at most one event every specified time interval (in milliseconds)
+   * */
+  maxSampleRate?: number
+
   /** Data schema. Will not be accessible at runtime */
   schema: Schema
 }


### PR DESCRIPTION
This adds the ability to specify a `maxSampleRate` for a telemetry event. This is useful in cases where you want to track something as a response to something happening at a high frequency, but don't want to reduce the amount of events actually being submitted.