### PR TITLE
feat: mark react as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
   "peerDependencies": {
     "react": "^18.2 || ^19.0.0"
   },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "packageManager": "pnpm@10.6.5",
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
### Description

React is listed as a `peerDependency`, but it's only actually used by the `@sanity/telemetry/react` subpath export. Consumers who only import from `@sanity/telemetry` (the root entrypoint) get unnecessary peer dependency warnings about missing React.

This adds `peerDependenciesMeta` to mark `react` as optional. The version constraint still applies when React is present, but package managers will no longer warn when it's absent.

### What to review

Single change in `package.json`: the addition of `peerDependenciesMeta` with `react` set to `optional: true`. Verify that the root entrypoint (`src/index.ts`) has no React imports, confirming React is only needed via the `/react` subpath.

### Testing

No automated tests needed. This is a packaging metadata change. You can verify by running `pnpm install` in a consuming project that does not have React installed and confirming no peer dependency warning is produced.